### PR TITLE
Set a max number for Int

### DIFF
--- a/src/helpers/generatePrismaFaker.ts
+++ b/src/helpers/generatePrismaFaker.ts
@@ -27,7 +27,7 @@ class PrismaFakerGenerator {
   models: Model[];
 
   readonly scalarMap: Record<string, string> = {
-    Int: 'faker.number.int()',
+    Int: 'faker.number.int({ max: 1000 })',
     BigInt: 'faker.number.bigInt()',
     Float: 'faker.number.float()',
     String: 'faker.string.sample()',


### PR DESCRIPTION
Prisma returns Int for 32 bit integers. Faker, as of the new update, returns values from 0 to 2^53 - 1.